### PR TITLE
small (~2KB) pickled size of F110Env, custom rendering support using callback functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ gym/f110_gym/unittest/maps/
 gym/f110_gym/unittest/centerline/
 docs/_build/
 *.mypy_cache/
+flycheck_*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 gym/f110_gym/unittest/maps/
 gym/f110_gym/unittest/centerline/
 docs/_build/
+*.mypy_cache/

--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -1,3 +1,4 @@
+import pickle
 import time
 import yaml
 import gym
@@ -245,6 +246,7 @@ def main():
         obs, step_reward, done, info = env.step(np.array([[steer, speed]]))
         laptime += step_reward
         env.render(mode='human')
+        
     print('Sim elapsed time:', laptime, 'Real elapsed time:', time.time()-start)
 
 if __name__ == '__main__':

--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -155,7 +155,7 @@ class PurePursuitPlanner:
         self.waypoints = np.loadtxt(conf.wpt_path, delimiter=conf.wpt_delim, skiprows=conf.wpt_rowskip)
 
     def render_waypoints(self, env_renderer):
-        'draw waypoints using EnvRenderer'
+        # draw waypoints using EnvRenderer
 
         e = env_renderer
         #points = self.waypoints

--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -13,7 +13,7 @@ Planner Helpers
 """
 @njit(fastmath=False, cache=True)
 def nearest_point_on_trajectory(point, trajectory):
-    '''
+    """
     Return the nearest point along the given piecewise linear trajectory.
 
     Same as nearest_point_on_line_segment, but vectorized. This method is quite fast, time constraints should
@@ -24,7 +24,7 @@ def nearest_point_on_trajectory(point, trajectory):
     point: size 2 numpy array
     trajectory: Nx2 matrix of (x,y) trajectory waypoints
         - these must be unique. If they are not unique, a divide by 0 error will destroy the world
-    '''
+    """
     diffs = trajectory[1:,:] - trajectory[:-1,:]
     l2s   = diffs[:,0]**2 + diffs[:,1]**2
     # this is equivalent to the elementwise dot product
@@ -47,12 +47,13 @@ def nearest_point_on_trajectory(point, trajectory):
 
 @njit(fastmath=False, cache=True)
 def first_point_on_trajectory_intersecting_circle(point, radius, trajectory, t=0.0, wrap=False):
-    ''' starts at beginning of trajectory, and find the first point one radius away from the given point along the trajectory.
+    """
+    starts at beginning of trajectory, and find the first point one radius away from the given point along the trajectory.
 
     Assumes that the first segment passes within a single radius of the point
 
     http://codereview.stackexchange.com/questions/86421/line-segment-to-circle-collision-algorithm
-    '''
+    """
     start_i = int(t)
     start_t = t % 1.0
     first_t = None
@@ -130,6 +131,9 @@ def first_point_on_trajectory_intersecting_circle(point, radius, trajectory, t=0
 
 @njit(fastmath=False, cache=True)
 def get_actuation(pose_theta, lookahead_point, position, lookahead_distance, wheelbase):
+    """
+    Returns actuation
+    """
     waypoint_y = np.dot(np.array([np.sin(-pose_theta), np.cos(-pose_theta)]), lookahead_point[0:2]-position)
     speed = lookahead_point[2]
     if np.abs(waypoint_y) < 1e-6:
@@ -151,13 +155,16 @@ class PurePursuitPlanner:
         self.drawn_waypoints = []
 
     def load_waypoints(self, conf):
-        # load waypoints
+        """
+        loads waypoints
+        """
         self.waypoints = np.loadtxt(conf.wpt_path, delimiter=conf.wpt_delim, skiprows=conf.wpt_rowskip)
 
-    def render_waypoints(self, env_renderer):
-        # draw waypoints using EnvRenderer
+    def render_waypoints(self, e):
+        """
+        update waypoints being drawn by EnvRenderer
+        """
 
-        e = env_renderer
         #points = self.waypoints
 
         points = np.vstack((self.waypoints[:, self.conf.wpt_xind], self.waypoints[:, self.conf.wpt_yind])).T
@@ -173,6 +180,9 @@ class PurePursuitPlanner:
                 self.drawn_waypoints[i].vertices = [scaled_points[i, 0], scaled_points[i, 1], 0.]
         
     def _get_current_waypoint(self, waypoints, lookahead_distance, position, theta):
+        """
+        gets the current waypoint to follow
+        """
         wpts = np.vstack((self.waypoints[:, self.conf.wpt_xind], self.waypoints[:, self.conf.wpt_yind])).T
         nearest_point, nearest_dist, t, i = nearest_point_on_trajectory(position, wpts)
         if nearest_dist < lookahead_distance:
@@ -191,6 +201,9 @@ class PurePursuitPlanner:
             return None
 
     def plan(self, pose_x, pose_y, pose_theta, lookahead_distance, vgain):
+        """
+        gives actuation given observation
+        """
         position = np.array([pose_x, pose_y])
         lookahead_point = self._get_current_waypoint(self.waypoints, lookahead_distance, position, pose_theta)
 
@@ -203,7 +216,9 @@ class PurePursuitPlanner:
         return speed, steering_angle
 
 def main():
-    # main entry point
+    """
+    main entry point
+    """
 
     work = {'mass': 3.463388126201571, 'lf': 0.15597534362552312, 'tlad': 0.82461887897713965, 'vgain': 0.90338203837889}
     

--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -6,6 +6,8 @@ from argparse import Namespace
 
 from numba import njit
 
+from pyglet.gl import GL_POINTS
+
 """
 Planner Helpers
 """
@@ -136,8 +138,6 @@ def get_actuation(pose_theta, lookahead_point, position, lookahead_distance, whe
     steering_angle = np.arctan(wheelbase/radius)
     return speed, steering_angle
 
-
-
 class PurePursuitPlanner:
     """
     Example Planner
@@ -148,10 +148,30 @@ class PurePursuitPlanner:
         self.load_waypoints(conf)
         self.max_reacquire = 20.
 
+        self.drawn_waypoints = []
+
     def load_waypoints(self, conf):
         # load waypoints
         self.waypoints = np.loadtxt(conf.wpt_path, delimiter=conf.wpt_delim, skiprows=conf.wpt_rowskip)
 
+    def render_waypoints(self, env_renderer):
+        'draw waypoints using EnvRenderer'
+
+        e = env_renderer
+        #points = self.waypoints
+
+        points = np.vstack((self.waypoints[:, self.conf.wpt_xind], self.waypoints[:, self.conf.wpt_yind])).T
+        
+        scaled_points = 50.*points
+
+        for i in range(points.shape[0]):
+            if len(self.drawn_waypoints) < points.shape[0]:
+                b = e.batch.add(1, GL_POINTS, None, ('v3f/stream', [scaled_points[i, 0], scaled_points[i, 1], 0.]),
+                                ('c3B/stream', [183, 193, 222]))
+                self.drawn_waypoints.append(b)
+            else:
+                self.drawn_waypoints[i].vertices = [scaled_points[i, 0], scaled_points[i, 1], 0.]
+        
     def _get_current_waypoint(self, waypoints, lookahead_distance, position, theta):
         wpts = np.vstack((self.waypoints[:, self.conf.wpt_xind], self.waypoints[:, self.conf.wpt_yind])).T
         nearest_point, nearest_dist, t, i = nearest_point_on_trajectory(position, wpts)
@@ -182,18 +202,40 @@ class PurePursuitPlanner:
 
         return speed, steering_angle
 
-
-if __name__ == '__main__':
+def main():
+    'main entry point'
 
     work = {'mass': 3.463388126201571, 'lf': 0.15597534362552312, 'tlad': 0.82461887897713965, 'vgain': 0.90338203837889}
+    
     with open('config_example_map.yaml') as file:
         conf_dict = yaml.load(file, Loader=yaml.FullLoader)
     conf = Namespace(**conf_dict)
 
+    planner = PurePursuitPlanner(conf, 0.17145+0.15875)
+
+    def render_callback(env_renderer):
+        'custom extra drawing function'
+
+        e = env_renderer
+
+        # update camera to follow car
+        x = e.cars[0].vertices[::2]
+        y = e.cars[0].vertices[1::2]
+        top, bottom, left, right = max(y), min(y), min(x), max(x)
+        e.score_label.x = left
+        e.score_label.y = top - 700
+        e.left = left - 800
+        e.right = right + 800
+        e.top = top + 800
+        e.bottom = bottom - 800
+
+        planner.render_waypoints(env_renderer)
+
     env = gym.make('f110_gym:f110-v0', map=conf.map_path, map_ext=conf.map_ext, num_agents=1)
+    env.add_render_callback(render_callback)
+    
     obs, step_reward, done, info = env.reset(np.array([[conf.sx, conf.sy, conf.stheta]]))
     env.render()
-    planner = PurePursuitPlanner(conf, 0.17145+0.15875)
 
     laptime = 0.0
     start = time.time()
@@ -204,3 +246,6 @@ if __name__ == '__main__':
         laptime += step_reward
         env.render(mode='human')
     print('Sim elapsed time:', laptime, 'Real elapsed time:', time.time()-start)
+
+if __name__ == '__main__':
+    main()

--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -204,7 +204,7 @@ class PurePursuitPlanner:
         return speed, steering_angle
 
 def main():
-    'main entry point'
+    # main entry point
 
     work = {'mass': 3.463388126201571, 'lf': 0.15597534362552312, 'tlad': 0.82461887897713965, 'vgain': 0.90338203837889}
     
@@ -215,7 +215,7 @@ def main():
     planner = PurePursuitPlanner(conf, 0.17145+0.15875)
 
     def render_callback(env_renderer):
-        'custom extra drawing function'
+        # custom extra drawing function
 
         e = env_renderer
 

--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -1,4 +1,3 @@
-import pickle
 import time
 import yaml
 import gym

--- a/gym/f110_gym/envs/base_classes.py
+++ b/gym/f110_gym/envs/base_classes.py
@@ -104,7 +104,8 @@ class RaceCar(object):
 
         # initialize scan sim
         if RaceCar.scan_simulator is None:
-            RaceCar.scan_simulator = ScanSimulator2D(num_beams, fov, seed=self.seed)
+            self.scan_rng = np.random.default_rng(seed=self.seed)
+            RaceCar.scan_simulator = ScanSimulator2D(num_beams, fov)
 
             scan_ang_incr = RaceCar.scan_simulator.get_increment()
 
@@ -188,7 +189,7 @@ class RaceCar(object):
         self.state[4] = pose[2]
         self.steer_buffer = np.empty((0, ))
         # reset scan random generator
-        RaceCar.scan_simulator.reset_rng(self.seed)
+        self.scan_rng = np.random.default_rng(seed=self.seed)
 
     def ray_cast_agents(self, scan):
         """
@@ -299,7 +300,7 @@ class RaceCar(object):
             self.state[4] = self.state[4] + 2*np.pi
 
         # update scan
-        current_scan = RaceCar.scan_simulator.scan(np.append(self.state[0:2], self.state[4]))
+        current_scan = RaceCar.scan_simulator.scan(np.append(self.state[0:2], self.state[4]), self.scan_rng)
 
         return current_scan
 

--- a/gym/f110_gym/envs/f110_env.py
+++ b/gym/f110_gym/envs/f110_env.py
@@ -176,6 +176,7 @@ class F110Env(gym.Env, utils.EzPickle):
         # rendering
         self.renderer = None
         self.current_obs = None
+        self.render_callbacks = []
 
     def __del__(self):
         """
@@ -337,6 +338,16 @@ class F110Env(gym.Env, utils.EzPickle):
         """
         self.sim.update_params(params, agent_idx=index)
 
+    def add_render_callback(self, callback_func):
+        """
+        Add extra drawing function to call during rendering.
+
+        Args:
+            callback_func (function (EnvRenderer) -> None): custom function to called during render()
+        """
+
+        self.render_callbacks.append(callback_func)
+
     def render(self, mode='human'):
         """
         Renders the environment with pyglet. Use mouse scroll in the window to zoom in/out, use mouse click drag to pan. Shows the agents, the map, current fps (bottom left corner), and the race information near as text.
@@ -356,6 +367,10 @@ class F110Env(gym.Env, utils.EzPickle):
             self.renderer = EnvRenderer(WINDOW_W, WINDOW_H)
             self.renderer.update_map(self.map_name, self.map_ext)
         self.renderer.update_obs(self.current_obs)
+
+        for render_callback in self.render_callbacks:
+            render_callback(self.renderer)
+        
         self.renderer.dispatch_events()
         self.renderer.on_draw()
         self.renderer.flip()

--- a/gym/f110_gym/envs/laser_models.py
+++ b/gym/f110_gym/envs/laser_models.py
@@ -317,18 +317,15 @@ class ScanSimulator2D(object):
     Init params:
         num_beams (int): number of beams in the scan
         fov (float): field of view of the laser scan
-        std_dev (float, default=0.01): standard deviation of the generated whitenoise in the scan
         eps (float, default=0.0001): ray tracing iteration termination condition
         theta_dis (int, default=2000): number of steps to discretize the angles between 0 and 2pi for look up
         max_range (float, default=30.0): maximum range of the laser
-        seed (int, default=123): seed for random number generator for the whitenoise in scan
     """
 
-    def __init__(self, num_beams, fov, std_dev=0.01, eps=0.0001, theta_dis=2000, max_range=30.0, seed=12345):
+    def __init__(self, num_beams, fov, eps=0.0001, theta_dis=2000, max_range=30.0):
         # initialization 
         self.num_beams = num_beams
         self.fov = fov
-        self.std_dev = std_dev
         self.eps = eps
         self.theta_dis = theta_dis
         self.max_range = max_range
@@ -343,9 +340,6 @@ class ScanSimulator2D(object):
         self.map_resolution = None
         self.dt = None
         
-        # white noise generator
-        self.rng = np.random.default_rng(seed=seed)
-
         # precomputing corresponding cosines and sines of the angle array
         theta_arr = np.linspace(0.0, 2*np.pi, num=theta_dis)
         self.sines = np.sin(theta_arr)
@@ -397,25 +391,14 @@ class ScanSimulator2D(object):
 
         return True
 
-    def reset_rng(self, seed):
-        """
-        Resets the generator object's random sequence by re-constructing the generator.
-
-        Args:
-            seed (int): seed for the generator
-
-        Returns:
-            None
-        """
-        self.rng = None
-        self.rng = np.random.default_rng(seed=seed)
-
-    def scan(self, pose):
+    def scan(self, pose, rng, std_dev=0.01):
         """
         Perform simulated 2D scan by pose on the given map
 
             Args:
                 pose (numpy.ndarray (3, )): pose of the scan frame (x, y, theta)
+                rng (numpy.random.Generator): random number generator to use for whitenoise in scan, or None
+                std_dev (float, default=0.01): standard deviation of the generated whitenoise in the scan
 
             Returns:
                 scan (numpy.ndarray (n, )): data array of the laserscan, n=num_beams
@@ -423,12 +406,17 @@ class ScanSimulator2D(object):
             Raises:
                 ValueError: when scan is called before a map is set
         """
+        
         if self.map_height is None:
             raise ValueError('Map is not set for scan simulator.')
+        
         scan = get_scan(pose, self.theta_dis, self.fov, self.num_beams, self.theta_index_increment, self.sines, self.cosines, self.eps, self.orig_x, self.orig_y, self.orig_c, self.orig_s, self.map_height, self.map_width, self.map_resolution, self.dt, self.max_range)
-        noise = self.rng.normal(0., self.std_dev, size=self.num_beams)
-        final_scan = scan + noise
-        return final_scan
+
+        if rng is not None:
+            noise = rng.normal(0., std_dev, size=self.num_beams)
+            scan += noise
+            
+        return scan
 
     def get_increment(self):
         return self.angle_increment
@@ -460,6 +448,7 @@ class ScanTests(unittest.TestCase):
         # self.skirk_scan = sample_scan['skirk']
 
     # def test_map_berlin(self):
+    #     scan_rng = np.random.default_rng(seed=12345)
     #     scan_sim = ScanSimulator2D(self.num_beams, self.fov)
     #     new_berlin = np.empty((self.num_test, self.num_beams))
     #     map_path = '../../../maps/berlin.yaml'
@@ -468,7 +457,7 @@ class ScanTests(unittest.TestCase):
     #     # scan gen loop
     #     for i in range(self.num_test):
     #         test_pose = self.test_poses[i]
-    #         new_berlin[i,:] = scan_sim.scan(test_pose)
+    #         new_berlin[i,:] = scan_sim.scan(test_pose, scan_rng)
     #     diff = self.berlin_scan - new_berlin
     #     mse = np.mean(diff**2)
     #     # print('Levine distance test, norm: ' + str(norm))
@@ -483,6 +472,7 @@ class ScanTests(unittest.TestCase):
     #     self.assertLess(mse, 2.)
 
     # def test_map_skirk(self):
+    #     scan_rng = np.random.default_rng(seed=12345)
     #     scan_sim = ScanSimulator2D(self.num_beams, self.fov)
     #     new_skirk = np.empty((self.num_test, self.num_beams))
     #     map_path = '../../../maps/skirk.yaml'
@@ -492,7 +482,7 @@ class ScanTests(unittest.TestCase):
     #     # scan gen loop
     #     for i in range(self.num_test):
     #         test_pose = self.test_poses[i]
-    #         new_skirk[i,:] = scan_sim.scan(test_pose)
+    #         new_skirk[i,:] = scan_sim.scan(test_pose, scan_rng)
     #     diff = self.skirk_scan - new_skirk
     #     mse = np.mean(diff**2)
     #     print('skirk distance test, mse: ' + str(mse))
@@ -508,6 +498,8 @@ class ScanTests(unittest.TestCase):
 
     def test_fps(self):
         # scan fps should be greater than 500
+
+        scan_rng = np.random.default_rng(seed=12345)
         scan_sim = ScanSimulator2D(self.num_beams, self.fov)
         map_path = '../envs/maps/berlin.yaml'
         map_ext = '.png'
@@ -517,7 +509,7 @@ class ScanTests(unittest.TestCase):
         start = time.time()
         for i in range(10000):
             x_test = i/10000
-            scan = scan_sim.scan(np.array([x_test, 0., 0.]))
+            scan = scan_sim.scan(np.array([x_test, 0., 0.]), scan_rng)
         end = time.time()
         fps = 10000/(end-start)
         # print('FPS test')
@@ -531,19 +523,22 @@ class ScanTests(unittest.TestCase):
         map_ext = '.png'
         it = 100
 
-        scan_sim = ScanSimulator2D(num_beams, fov, seed=12345)
+        scan_rng = np.random.default_rng(seed=12345)
+        scan_sim = ScanSimulator2D(num_beams, fov)
         scan_sim.set_map(map_path, map_ext)
-        scan1 = scan_sim.scan(np.array([0., 0., 0.]))
-        scan2 = scan_sim.scan(np.array([0., 0., 0.]))
+        scan1 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
+        scan2 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
         for i in range(it):
-            scan3 = scan_sim.scan(np.array([0., 0., 0.]))
-        scan4 = scan_sim.scan(np.array([0., 0., 0.]))
-        scan_sim.reset_rng(12345)
-        scan5 = scan_sim.scan(np.array([0., 0., 0.]))
-        scan2 = scan_sim.scan(np.array([0., 0., 0.]))
+            scan3 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
+        scan4 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
+        
+        scan_rng = np.random.default_rng(seed=12345)
+        scan5 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
+        scan2 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
         for i in range(it):
-            _ = scan_sim.scan(np.array([0., 0., 0.]))
-        scan6 = scan_sim.scan(np.array([0., 0., 0.]))
+            _ = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
+        scan6 = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
+        
         self.assertTrue(np.allclose(scan1, scan5))
         self.assertFalse(np.allclose(scan1, scan2))
         self.assertFalse(np.allclose(scan1, scan3))
@@ -554,18 +549,19 @@ def main():
     num_beams = 1080
     fov = 4.7
     # map_path = '../envs/maps/berlin.yaml'
-    map_path = '/home/f1tenth-eval/tunercar/es/maps/map0.yaml'
+    map_path = '../../../examples/example_map.yaml'
     map_ext = '.png'
+    scan_rng = np.random.default_rng(seed=12345)
     scan_sim = ScanSimulator2D(num_beams, fov)
     scan_sim.set_map(map_path, map_ext)
-    scan = scan_sim.scan(np.array([0., 0., 0.]))
+    scan = scan_sim.scan(np.array([0., 0., 0.]), scan_rng)
 
     # fps test
     import time
     start = time.time()
     for i in range(10000):
         x_test = i/10000
-        scan = scan_sim.scan(np.array([x_test, 0., 0.]))
+        scan = scan_sim.scan(np.array([x_test, 0., 0.]), scan_rng)
     end = time.time()
     fps = (end-start)/10000
     print('FPS test')
@@ -584,7 +580,7 @@ def main():
         # x_ani = i * 3. / num_iter
         theta_ani = -i * 2 * np.pi / num_iter
         x_ani = 0.
-        current_scan = scan_sim.scan(np.array([x_ani, 0., theta_ani]))
+        current_scan = scan_sim.scan(np.array([x_ani, 0., theta_ani]), scan_rng)
         print(np.max(current_scan))
         line.set_data(theta, current_scan)
         return line, 
@@ -593,7 +589,7 @@ def main():
 
 if __name__ == '__main__':
     unittest.main()
-    # main()
+    #main()
 
     # import time 
     # pt_a = np.array([1., 1.])

--- a/gym/setup.py
+++ b/gym/setup.py
@@ -5,5 +5,5 @@ setup(name='f110_gym',
       author='Hongrui Zheng',
       author_email='billyzheng.bz@gmail.com',
       url='https://f1tenth.org',
-      install_requires=['gym', 'numpy', 'Pillow', 'scipy', 'numba', 'pyyaml']
+      install_requires=['gym', 'numpy', 'Pillow', 'scipy', 'numba', 'pyyaml', 'pyglet', 'pyopengl']
       )


### PR DESCRIPTION
I moved several large data structures (such as map and current lidar scan) to be class variables to support efficient pickling of `F110Env` objects. Currently this is around 2KB, originally it was several (tens of?) MB. The renderer also was moven to a class variable, since it can't be pickled.

Also, I generalized the custom rendering to be exposed to the controllers using callback, and modified `waypoint_follow.py` to draw the race line and follow the car:

```
    def render_callback(env_renderer):
        'custom extra drawing function'

        e = env_renderer

        # update camera to follow car
        x = e.cars[0].vertices[::2]
        y = e.cars[0].vertices[1::2]
        top, bottom, left, right = max(y), min(y), min(x), max(x)
        e.score_label.x = left
        e.score_label.y = top - 700
        e.left = left - 800
        e.right = right + 800
        e.top = top + 800
        e.bottom = bottom - 800

        planner.render_waypoints(env_renderer)

...

    def render_waypoints(self, env_renderer):
        'draw waypoints using EnvRenderer'

        e = env_renderer
        #points = self.waypoints

        points = np.vstack((self.waypoints[:, self.conf.wpt_xind], self.waypoints[:, self.conf.wpt_yind])).T
        
        scaled_points = 50.*points

        for i in range(points.shape[0]):
            if len(self.drawn_waypoints) < points.shape[0]:
                b = e.batch.add(1, GL_POINTS, None, ('v3f/stream', [scaled_points[i, 0], scaled_points[i, 1], 0.]),
                                ('c3B/stream', [183, 193, 222]))
                self.drawn_waypoints.append(b)
            else:
                self.drawn_waypoints[i].vertices = [scaled_points[i, 0], scaled_points[i, 1], 0.]
```