### PR TITLE
update _check_done return type

### DIFF
--- a/gym/f110_gym/envs/f110_env.py
+++ b/gym/f110_gym/envs/f110_env.py
@@ -225,7 +225,7 @@ class F110Env(gym.Env, utils.EzPickle):
         
         done = (self.collisions[self.ego_idx]) or np.all(self.toggle_list >= 4)
         
-        return done, self.toggle_list >= 4
+        return bool(done), self.toggle_list >= 4
 
     def _update_state(self, obs_dict):
         """


### PR DESCRIPTION
changed the the type of what `F110Env._check_done()` returns. 
It made the `done` returned from the `F110Env.step()` method a bool. 
Before it was not and created issues when wrapping the environment in the gym `NormalizeReward` wrapper.