### PR TITLE
Fix timestep parameter doesn't change the physics timestep

### DIFF
--- a/gym/f110_gym/envs/base_classes.py
+++ b/gym/f110_gym/envs/base_classes.py
@@ -381,10 +381,10 @@ class Simulator(object):
         # initializing agents
         for i in range(self.num_agents):
             if i == ego_idx:
-                ego_car = RaceCar(params, self.seed, is_ego=True)
+                ego_car = RaceCar(params, self.seed, is_ego=True, time_step=self.time_step)
                 self.agents.append(ego_car)
             else:
-                agent = RaceCar(params, self.seed)
+                agent = RaceCar(params, self.seed, is_ego=False, time_step=self.time_step)
                 self.agents.append(agent)
 
     def set_map(self, map_path, map_ext):

--- a/gym/f110_gym/envs/f110_env.py
+++ b/gym/f110_gym/envs/f110_env.py
@@ -175,7 +175,7 @@ class F110Env(gym.Env):
         self.start_rot = np.eye(2)
 
         # initiate stuff
-        self.sim = Simulator(self.params, self.num_agents, self.seed)
+        self.sim = Simulator(self.params, self.num_agents, self.seed, time_step=self.timestep)
         self.sim.set_map(self.map_path, self.map_ext)
 
         # stateful observations for rendering


### PR DESCRIPTION
On env `f110_gym:f110-v0` changing the timestep won't change the timestep on the simulator. This small fix changes this behavior.