### PR TITLE
RK4 Integration

### DIFF
--- a/gym/f110_gym/envs/base_classes.py
+++ b/gym/f110_gym/envs/base_classes.py
@@ -66,7 +66,7 @@ class RaceCar(object):
     scan_angles = None
     side_distances = None
 
-    def __init__(self, params, seed, is_ego=False, time_step=0.01, num_beams=1080, fov=4.7, integrator=Integrator.RK4):
+    def __init__(self, params, seed, is_ego=False, time_step=0.01, num_beams=1080, fov=4.7, integrator=Integrator.Euler):
         """
         Init function
 

--- a/gym/f110_gym/envs/base_classes.py
+++ b/gym/f110_gym/envs/base_classes.py
@@ -27,6 +27,8 @@ Prototype of base classes
 Replacement of the old RaceCar, Simulator classes in C++
 Author: Hongrui Zheng
 """
+from enum import Enum
+import warnings
 
 import numpy as np
 from numba import njit
@@ -34,6 +36,11 @@ from numba import njit
 from f110_gym.envs.dynamic_models import vehicle_dynamics_st, pid
 from f110_gym.envs.laser_models import ScanSimulator2D, check_ttc_jit, ray_cast
 from f110_gym.envs.collision_models import get_vertices, collision_multiple
+
+class Integrator(Enum):
+    RK4 = 1
+    Euler = 2
+
 
 class RaceCar(object):
     """

--- a/gym/f110_gym/envs/f110_env.py
+++ b/gym/f110_gym/envs/f110_env.py
@@ -30,7 +30,7 @@ from gym import error, spaces, utils
 from gym.utils import seeding
 
 # base classes
-from f110_gym.envs.base_classes import Simulator
+from f110_gym.envs.base_classes import Simulator, Integrator
 
 # others
 import numpy as np
@@ -144,6 +144,12 @@ class F110Env(gym.Env):
         except:
             self.ego_idx = 0
 
+        # default integrator
+        try:
+            self.integrator = kwargs['integrator']
+        except:
+            self.integrator = Integrator.RK4
+
         # radius to consider done
         self.start_thresh = 0.5  # 10cm
 
@@ -175,7 +181,7 @@ class F110Env(gym.Env):
         self.start_rot = np.eye(2)
 
         # initiate stuff
-        self.sim = Simulator(self.params, self.num_agents, self.seed, time_step=self.timestep)
+        self.sim = Simulator(self.params, self.num_agents, self.seed, time_step=self.timestep, integrator=self.integrator)
         self.sim.set_map(self.map_path, self.map_ext)
 
         # stateful observations for rendering

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='f110_gym',
                         'scipy>=1.7.3',
                         'numba>=0.55.2',
                         'pyyaml>=5.3.1',
-                        'pyglet',
+                        'pyglet<1.5',
                         'pyopengl']
       )


### PR DESCRIPTION
Tested RK4 integration method. Changelog below:

- Example of difference in RK4 vs Euler
     > Change integration method in `waypoint_follow.py` to `Integration.Euler` and observe a crash.
- Added Integrator enum
- Created integrator variable to environment creation, so users can specify which method they'd like
- Benchmarked speed on a single scenario. Waypoint follow with rendering off
      > Euler -> Real elapsed time: 2.509 sec
      > RK4   -> Real elapsed time: 2.595 sec
- Updated dependency specification for pyglet, fixing API error with `pyglet>1.5`