### PR TITLE
Fix bug in RK4 integration

### DIFF
--- a/gym/f110_gym/envs/base_classes.py
+++ b/gym/f110_gym/envs/base_classes.py
@@ -326,7 +326,7 @@ class RaceCar(object):
             k3_state = self.state + self.time_step*(k2/2)
 
             k3 = vehicle_dynamics_st(
-                k2_state,
+                k3_state,
                 np.array([sv, accl]),
                 self.params['mu'],
                 self.params['C_Sf'],


### PR DESCRIPTION
The 3rd step of RK4 integration used `k2_state` instead of the newly computed `k3_state`. This PR fixes this bug.