### PR TITLE
Fix division by zero in laser_models.py

### DIFF
--- a/gym/f110_gym/envs/laser_models.py
+++ b/gym/f110_gym/envs/laser_models.py
@@ -185,7 +185,7 @@ def get_scan(pose, theta_dis, fov, num_beams, theta_index_increment, sines, cosi
 
     return scan
 
-@njit(cache=True)
+@njit(cache=True, error_model='numpy')
 def check_ttc_jit(scan, vel, scan_angles, cosines, side_distances, ttc_thresh):
     """
     Checks the iTTC of each beam in a scan for collision with environment


### PR DESCRIPTION
I changed the error_model to "numpy" from the default "python". This controls the divide by zero behavior as explained in the [documentation](https://numba.readthedocs.io/en/stable/reference/jit-compilation.html#numba.jit). The result it that the division by zero will produce -inf or +inf.

With this change I had no more divide by zero crashes.