### PR TITLE
Separate scan and pose update, non-scan dependent collision checking

### DIFF
--- a/examples/waypoint_follow.py
+++ b/examples/waypoint_follow.py
@@ -298,7 +298,7 @@ def main():
         "vgain": 1,
     }
 
-    num_agents = 3
+    num_agents = 1
     env = gym.make(
         "f110_gym:f110-v0",
         config={
@@ -306,11 +306,12 @@ def main():
             "num_agents": num_agents,
             "timestep": 0.01,
             "integrator": "rk4",
+            "scan": False,
             "control_input": ["speed", "steering_angle"],
             "model": "st",
             "observation_config": {"type": "kinematic_state"},
             "params": {"mu": 1.0},
-            "reset_config": {"type": "random_static"},
+            # "reset_config": {"type": "random_static"},
         },
         render_mode="human",
     )

--- a/gym/f110_gym/envs/action.py
+++ b/gym/f110_gym/envs/action.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from abc import abstractmethod
 from enum import Enum
 from typing import Any, Dict, Tuple

--- a/gym/f110_gym/envs/base_classes.py
+++ b/gym/f110_gym/envs/base_classes.py
@@ -360,6 +360,8 @@ class RaceCar(object):
         # update attribute
         agent_scans[agent_index] = new_scan
 
+        return new_scan
+
 
 class Simulator(object):
     """

--- a/gym/f110_gym/envs/collision_models.py
+++ b/gym/f110_gym/envs/collision_models.py
@@ -186,7 +186,7 @@ def collision(vertices1, vertices2):
     return False
 
 
-# @njit(cache=True)
+@njit(cache=True)
 def collision_multiple(vertices):
     """
     Check pair-wise collisions for all provided vertices

--- a/gym/f110_gym/envs/collision_models.py
+++ b/gym/f110_gym/envs/collision_models.py
@@ -29,6 +29,10 @@ Author: Hongrui Zheng
 
 import numpy as np
 from numba import njit
+from numba.np.extensions import cross2d
+import jax.numpy as jnp
+from jax import jit
+import jax
 
 
 @njit(cache=True)
@@ -182,7 +186,7 @@ def collision(vertices1, vertices2):
     return False
 
 
-@njit(cache=True)
+# @njit(cache=True)
 def collision_multiple(vertices):
     """
     Check pair-wise collisions for all provided vertices
@@ -211,6 +215,56 @@ def collision_multiple(vertices):
                 collision_idx[j] = i
 
     return collisions, collision_idx
+
+
+# @njit(cache=True)
+@jit
+def collision_multiple_map(vertices, pixel_centers):
+    """
+    Check pair-wise collisions for all provided vertices
+
+    Args:
+        vertices (np.ndarray (num_bodies, 4, 2)): agent rectangle vertices, ccw winding order
+        pixel_centers (np.ndarray (HxW, 2)): x, y position of pixel centers of map image
+        map_occupied (np.ndarray (HxW, )): occupancy indicator of map_image
+
+    Returns:
+        collisions (np.ndarray (num_vertices, )): whether each body is in collision with map
+    """
+    collisions = jnp.zeros((vertices.shape[0],))
+
+    # TODO: reduce check size, only pixel_centers occupied around current poses
+    # NOTE: this doesn't work with jit since pixel_center sizes changes
+    # centers = jnp.mean(vertices, axis=1)
+    # dist = jnp.abs(all_pixel_centers[:, None] - centers)
+    # effective_ind = jnp.where(jnp.logical_and(dist[:, :, 0] < 0.5, dist[:, :, 1] < 0.5))
+    # pixel_centers = all_pixel_centers[:, None][effective_ind]
+
+    # check if center of pixel to the LEFT of all 4 edges
+    # loop because vectorizing is way slower
+    for car_ind in range(vertices.shape[0]):
+        left_of = jnp.empty((4, pixel_centers.shape[0]))
+        for v_ind in range(-1, 3):
+            edge = vertices[car_ind, v_ind + 1] - vertices[car_ind, v_ind]
+            center_p = pixel_centers - vertices[car_ind, v_ind]
+            left_of = left_of.at[v_ind + 1, :].set((jnp.cross(center_p, edge) <= 0))
+        ls = jnp.any((jnp.sum(left_of, axis=0) == 4.0))
+        collisions = collisions.at[car_ind].set(jnp.where(ls, 1.0, 0.0))
+
+    # center_vecs = (
+    #     pixel_centers[:, None, None] - vertices
+    # )  # result is (HxW, num_bodies, 4, 2)
+    # cross_prod = np.cross(edges, center_vecs, -1)  # cross_prod is (HxW, num_bodeis, 4)
+    # (pix_ind, body_ind, edge_ind) = np.where((cross_prod < 0))
+
+    # check if enclosed pixels occupied, inflate?
+    # inside_occupied = map_occupied[pix_ind]
+    # which_collision = np.unique(body_ind[np.where(inside_occupied)[0]])
+    # which_collision = np.unique(body_ind)
+
+    # figure out which car collided
+    # collisions[which_collision] = 1
+    return collisions
 
 
 """

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "requests",
         "shapely",
         "opencv-python",
+        "jax[cpu]",
     ],
     extras_require={
         "dev": [

--- a/tests/test_f110_env.py
+++ b/tests/test_f110_env.py
@@ -81,7 +81,7 @@ class TestEnvInterface(unittest.TestCase):
             for k in obs0:
                 self.assertTrue(
                     np.allclose(obs0[k], obs1[k]),
-                    f"Observations {k} should be the same",
+                    f"Observations {k} should be the same, got {obs0[k]} and {obs1[k]}",
                 )
             self.assertTrue(done0 == done1, "Done should be the same")
             t += 1


### PR DESCRIPTION
Separated scan and pose updates.
Implemented 3 different collision checking methods:
1. jax jit with loops
3. jax jit vectorized
4. numba jit with loops

Benchmarking with 5 seconds sim time:
- 1 vehicle: 
    - jax jit loops: ~0.25s
    - jax jit vectorized: ~0.25s
    - numba jit loops: ~0.34s
    - with scan: ~0.23s
- 5 vehicles:
    - jax jit loops: ~0.78s
    - jax jit vectorized: ~0.65s
    - numba jit loops: ~1.55s
    - with scan: ~1.68s
- 30 vehicles:
    - jax jit loops: ~4.15s
    - jax jit vectorized: ~3.45s
    - numba jit loops: ~8.99s
    - with scan: ~30.8s