### PR TITLE
Fix call edt only once

### DIFF
--- a/gym/f110_gym/envs/laser_models.py
+++ b/gym/f110_gym/envs/laser_models.py
@@ -448,6 +448,9 @@ class ScanSimulator2D(object):
         self.map_height = None
         self.map_width = None
         self.map_resolution = None
+        self.track = None
+        self.map_img = None
+        self.origin = None
         self.dt = None
 
         # precomputing corresponding cosines and sines of the angle array
@@ -465,6 +468,9 @@ class ScanSimulator2D(object):
             Returns:
                 flag (bool): if image reading and loading is successful
         """
+        if self.track and self.track.spec.name == map_name:
+            return True
+
         self.track = Track.from_track_name(map_name)
 
         # load map image

--- a/tests/test_f110_env.py
+++ b/tests/test_f110_env.py
@@ -187,8 +187,8 @@ class TestEnvInterface(unittest.TestCase):
             "num_agents": num_agents,
             "observation_config": {"type": "kinematic_state"},
         }
-        vec_env = gym.vector.make(
-            "f110_gym:f110-v0", asynchronous=True, config=config, num_envs=num_envs
+        vec_env = gym.make_vec(
+            "f110_gym:f110-v0", vectorization_mode="async", config=config, num_envs=num_envs
         )
 
         rnd_poses = np.random.random((2, 3))
@@ -219,8 +219,8 @@ class TestEnvInterface(unittest.TestCase):
             "observation_config": {"type": "kinematic_state"},
             "reset_config": {"type": "rl_random_random"},
         }
-        vec_env = gym.vector.make(
-            "f110_gym:f110-v0", asynchronous=False, config=config, num_envs=num_envs
+        vec_env = gym.make_vec(
+            "f110_gym:f110-v0", vectorization_mode="sync", config=config, num_envs=num_envs,
         )
 
         obss, infos = vec_env.reset()


### PR DESCRIPTION
The current gym calls `set_map` multiple times, every time recomputing the distance transform.
I added a simple check on the track name to avoid recomputing the edt for the same track.

It makes `gym.make` faster and improves issues related to #106, #107.