### PR TITLE
Use provided seed when calling F110Env.reset

### DIFF
--- a/f1tenth_gym/envs/f110_env.py
+++ b/f1tenth_gym/envs/f110_env.py
@@ -364,7 +364,7 @@ class F110Env(gym.Env):
             info (dict): auxillary information dictionary
         """
         if seed is not None:
-            np.random.seed(seed=self.seed)
+            np.random.seed(seed=seed)
         super().reset(seed=seed)
 
         # reset counters and data members


### PR DESCRIPTION
I noticed that providing the seed value when calling `F110Env.reset()` function is not working as expect. The seed value from config is used instead of the one provided in the arguments. 