### PR TITLE
LiDAR scan issue due to position offset

### DIFF
--- a/gym/f110_gym/envs/f110_env.py
+++ b/gym/f110_gym/envs/f110_env.py
@@ -89,6 +89,8 @@ class F110Env(gym.Env):
             timestep (float, default=0.01): physics timestep
 
             ego_idx (int, default=0): ego's index in list of agents
+            
+            lidar_dist (float, default=0): vertical distance between LiDAR and backshaft
     """
     metadata = {'render.modes': ['human', 'human_fast']}
 
@@ -149,6 +151,12 @@ class F110Env(gym.Env):
             self.integrator = kwargs['integrator']
         except:
             self.integrator = Integrator.RK4
+            
+        # default LiDAR position
+        try:
+            self.lidar_dist = kwargs['lidar_dist']
+        except:
+            self.lidar_dist = 0.0
 
         # radius to consider done
         self.start_thresh = 0.5  # 10cm
@@ -181,7 +189,7 @@ class F110Env(gym.Env):
         self.start_rot = np.eye(2)
 
         # initiate stuff
-        self.sim = Simulator(self.params, self.num_agents, self.seed, time_step=self.timestep, integrator=self.integrator)
+        self.sim = Simulator(self.params, self.num_agents, self.seed, time_step=self.timestep, integrator=self.integrator, lidar_dist=self.lidar_dist)
         self.sim.set_map(self.map_path, self.map_ext)
 
         # stateful observations for rendering


### PR DESCRIPTION
There is an error in the simulator that the LiDAR scan beams are not shooting from the front of car. Instead, it is from behind. This is because the code in f1tenth_gym (not in f1tenth_gym_ros) assumes that the LiDAR frame is same as the car frame. 

To fix this issue in f1tenth_gym, I separate the two frames by shifting the pose of LiDAR by a distance named "lidar_dist". This variable is accessible from bridge node in f1tenth_gym_ros now.

To see the final effect, please review this with the updated f1tenth_gym_ros repo: https://github.com/Carperis/f1tenth_gym_ros/tree/sam_fix_lidar_issue

The following is a brief comparison:
<img width="860" alt="iShot_2025-03-22_05 17 15" src="https://github.com/user-attachments/assets/8fb74d45-965f-469b-95c7-132b2b93adc6" />