### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the repository of the F1TENTH Gym environment.
 
-This project is still under heavy developement.
+This project is still under heavy development.
 
 You can find the [documentation](https://f1tenth-gym.readthedocs.io/en/latest/) of the environment here.
 


### PR DESCRIPTION
## Summary
- correct spelling mistake in README (development)

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gym')*
- `pip install gym==0.19.0` *(fails: extras_require must be a dictionary)*

------
https://chatgpt.com/codex/tasks/task_e_68964c590b288320b2eac8a669dbfc27